### PR TITLE
010/020/030/040

### DIFF
--- a/grammars/m68k.cson
+++ b/grammars/m68k.cson
@@ -45,7 +45,7 @@
     'name': 'storage.other.register.m68k'
   }
   {
-    'match': '\\b(?i)([as]bcd(\\.b)?|(add|sub)[iqx]?(\\.[bwl])?|adda(\\.[wl])?|(and|eor|or)(i)?(\\.[bwl])?|(rox?|[al]s)[lr](\\.[bwl])?|b(chg|clr|set|tst)(\\.[bl])?|bf(chg|clr|extu|exts|ffo|ins|set|tst)|chk(\\.[wl])?|chk2(\\.[bwl])?|clr(\\.[bwl])?|cas(\\.[bwl])?|cas2(\\.[wl])?|cmp[im2]?(\\.[bwl])?|cmpa(\\.[wl])?|divs|divu|exg(\\.l)?|ext(\\.[wl])?|extb.l|illegal|lea(\\.l)?|link|move[amp](\\.[wl])?|moveq(\\.l)?|move(\\.[bwl])?|muls|mulu|nbcd(\\.b)?|(negx?|not)(\\.[bwl])?|nop|pea(\\.l)?|reset|rte|rtri|rtd|rts|s(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)(\\.b)?|stop|swap(\\.l)?|tas(\\.b)?|trap|trapv|trap(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)|tst|tst\\.b|tst\\.w|tst\\.l|unlk|pack|unpk)(?-i)\\b'
+    'match': '\\b(?i)([as]bcd(\\.b)?|(add|sub)[iqx]?(\\.[bwl])?|adda(\\.[wl])?|(and|eor|or)(i)?(\\.[bwl])?|(rox?|[al]s)[lr](\\.[bwl])?|b(chg|clr|set|tst)(\\.[bl])?|bf(chg|clr|extu|exts|ffo|ins|set|tst)|chk(\\.[wl])?|chk2(\\.[bwl])?|clr(\\.[bwl])?|cas(\\.[bwl])?|cas2(\\.[wl])?|cmp[im2]?(\\.[bwl])?|cmpa(\\.[wl])?|divs|divu|exg(\\.l)?|ext(\\.[wl])?|extb.l|illegal|lea(\\.l)?|link|move[amp](\\.[wl])?|moveq(\\.l)?|movec(\\.l)?|move(\\.[bwl])?|moves(\\.[bwl])?|muls|mulu|nbcd(\\.b)?|(negx?|not)(\\.[bwl])?|nop|pea(\\.l)?|reset|rte|rtri|rtd|rts|s(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)(\\.b)?|stop|swap(\\.l)?|tas(\\.b)?|trap|trapv|trap(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)|tst|tst\\.b|tst\\.w|tst\\.l|unlk|pack|unpk)(?-i)\\b'
     'name': 'support.mnemonic.m68k'
   }
   {

--- a/grammars/m68k.cson
+++ b/grammars/m68k.cson
@@ -41,7 +41,7 @@
     'name': 'constant.numeric.hex.m68k'
   }
   {
-    'match': '\\b(?i)([ad]([0-7])|sr|sp|pc|usp|dfc|sfc|vbr)(?-i)\\b'
+    'match': '\\b(?i)([ad]([0-7])|sr|sp|pc|usp|dfc|sfc|vbr|cacr|caar|msp|isp)(?-i)\\b'
     'name': 'storage.other.register.m68k'
   }
   {

--- a/grammars/m68k.cson
+++ b/grammars/m68k.cson
@@ -45,7 +45,7 @@
     'name': 'storage.other.register.m68k'
   }
   {
-    'match': '\\b(?i)([as]bcd(\\.b)?|(add|sub)[iqx]?(\\.[bwl])?|adda(\\.[wl])?|(and|eor|or)(i)?(\\.[bwl])?|(rox?|[al]s)[lr](\\.[bwl])?|b(chg|clr|set|tst)(\\.[bl])?|chk(\\.w)?|clr(\\.[bwl])?|cmp[im]?(\\.[bwl])?|cmpa(\\.[wl])?|divs|divu|exg(\\.l)?|ext(\\.[wl])?|illegal|lea(\\.l)?|link|move[amp](\\.[wl])?|moveq(\\.l)?|move(\\.[bwl])?|muls|mulu|nbcd(\\.b)?|(negx?|not)(\\.[bwl])?|nop|pea(\\.l)?|reset|rte|rtr|rts|s(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)(\\.b)?|stop|swap(\\.l)?|tas(\\.b)?|trap|trapv|tst|tst\\.b|tst\\.w|tst\\.l|unlk)(?-i)\\b'
+    'match': '\\b(?i)([as]bcd(\\.b)?|(add|sub)[iqx]?(\\.[bwl])?|adda(\\.[wl])?|(and|eor|or)(i)?(\\.[bwl])?|(rox?|[al]s)[lr](\\.[bwl])?|b(chg|clr|set|tst)(\\.[bl])?|chk(\\.[wl])?|chk2(\\.[bwl])?|clr(\\.[bwl])?|cmp[im2]?(\\.[bwl])?|cmpa(\\.[wl])?|divs|divu|exg(\\.l)?|ext(\\.[wl])?|extb.l|illegal|lea(\\.l)?|link|move[amp](\\.[wl])?|moveq(\\.l)?|move(\\.[bwl])?|muls|mulu|nbcd(\\.b)?|(negx?|not)(\\.[bwl])?|nop|pea(\\.l)?|reset|rte|rtri|rtd|rts|s(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)(\\.b)?|stop|swap(\\.l)?|tas(\\.b)?|trap|trapv|trap(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)|tst|tst\\.b|tst\\.w|tst\\.l|unlk)(?-i)\\b'
     'name': 'support.mnemonic.m68k'
   }
   {

--- a/grammars/m68k.cson
+++ b/grammars/m68k.cson
@@ -41,7 +41,7 @@
     'name': 'constant.numeric.hex.m68k'
   }
   {
-    'match': '\\b(?i)([ad]([0-7])|sr|sp|pc|usp)(?-i)\\b'
+    'match': '\\b(?i)([ad]([0-7])|sr|sp|pc|usp|dfc|sfc|vbr)(?-i)\\b'
     'name': 'storage.other.register.m68k'
   }
   {

--- a/grammars/m68k.cson
+++ b/grammars/m68k.cson
@@ -45,7 +45,7 @@
     'name': 'storage.other.register.m68k'
   }
   {
-    'match': '\\b(?i)([as]bcd(\\.b)?|(add|sub)[iqx]?(\\.[bwl])?|adda(\\.[wl])?|(and|eor|or)(i)?(\\.[bwl])?|(rox?|[al]s)[lr](\\.[bwl])?|b(chg|clr|set|tst)(\\.[bl])?|bf(chg|clr|extu|exts|ffo|ins|set|tst)|chk(\\.[wl])?|chk2(\\.[bwl])?|clr(\\.[bwl])?|cmp[im2]?(\\.[bwl])?|cmpa(\\.[wl])?|divs|divu|exg(\\.l)?|ext(\\.[wl])?|extb.l|illegal|lea(\\.l)?|link|move[amp](\\.[wl])?|moveq(\\.l)?|move(\\.[bwl])?|muls|mulu|nbcd(\\.b)?|(negx?|not)(\\.[bwl])?|nop|pea(\\.l)?|reset|rte|rtri|rtd|rts|s(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)(\\.b)?|stop|swap(\\.l)?|tas(\\.b)?|trap|trapv|trap(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)|tst|tst\\.b|tst\\.w|tst\\.l|unlk|pack|unpk)(?-i)\\b'
+    'match': '\\b(?i)([as]bcd(\\.b)?|(add|sub)[iqx]?(\\.[bwl])?|adda(\\.[wl])?|(and|eor|or)(i)?(\\.[bwl])?|(rox?|[al]s)[lr](\\.[bwl])?|b(chg|clr|set|tst)(\\.[bl])?|bf(chg|clr|extu|exts|ffo|ins|set|tst)|chk(\\.[wl])?|chk2(\\.[bwl])?|clr(\\.[bwl])?|cas(\\.[bwl])?|cas2(\\.[wl])?|cmp[im2]?(\\.[bwl])?|cmpa(\\.[wl])?|divs|divu|exg(\\.l)?|ext(\\.[wl])?|extb.l|illegal|lea(\\.l)?|link|move[amp](\\.[wl])?|moveq(\\.l)?|move(\\.[bwl])?|muls|mulu|nbcd(\\.b)?|(negx?|not)(\\.[bwl])?|nop|pea(\\.l)?|reset|rte|rtri|rtd|rts|s(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)(\\.b)?|stop|swap(\\.l)?|tas(\\.b)?|trap|trapv|trap(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)|tst|tst\\.b|tst\\.w|tst\\.l|unlk|pack|unpk)(?-i)\\b'
     'name': 'support.mnemonic.m68k'
   }
   {

--- a/grammars/m68k.cson
+++ b/grammars/m68k.cson
@@ -41,13 +41,59 @@
     'name': 'constant.numeric.hex.m68k'
   }
   {
-    'match': '\\b(?i)([ad]([0-7])|sr|sp|pc|usp|dfc|sfc|vbr|cacr|caar|msp|isp)(?-i)\\b'
+    'match': '\\b(?i)([ad]([0-7])|sr|sp|pc)(?-i)\\b'
     'name': 'storage.other.register.m68k'
   }
   {
-    'match': '\\b(?i)([as]bcd(\\.b)?|(add|sub)[iqx]?(\\.[bwl])?|adda(\\.[wl])?|(and|eor|or)(i)?(\\.[bwl])?|(rox?|[al]s)[lr](\\.[bwl])?|b(chg|clr|set|tst)(\\.[bl])?|bf(chg|clr|extu|exts|ffo|ins|set|tst)|chk(\\.[wl])?|chk2(\\.[bwl])?|clr(\\.[bwl])?|cas(\\.[bwl])?|cas2(\\.[wl])?|cmp[im2]?(\\.[bwl])?|cmpa(\\.[wl])?|divs|divu|exg(\\.l)?|ext(\\.[wl])?|extb.l|illegal|lea(\\.l)?|link|move[amp](\\.[wl])?|moveq(\\.l)?|movec(\\.l)?|move(\\.[bwl])?|moves(\\.[bwl])?|muls|mulu|nbcd(\\.b)?|(negx?|not)(\\.[bwl])?|nop|pea(\\.l)?|reset|rte|rtri|rtd|rts|s(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)(\\.b)?|stop|swap(\\.l)?|tas(\\.b)?|trap|trapv|trap(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)|tst|tst\\.b|tst\\.w|tst\\.l|unlk|pack|unpk)(?-i)\\b'
+    'match': '\\b(?i)(usp|dfc|sfc|vbr|cacr|caar|msp|isp)(?-i)\\b'
+    'name': 'storage.other.register.privileged.m68k'
+  }
+  {
+    'match': '\\b(?i)((moves|movec)(\\.[bwl])?)\\s+([ad]([0-7])|(.+)),((usp|dfc|sfc|vbr|cacr|caar|msp|isp)|(.+))?(?-i)\\b'
+    'captures':
+        2: 'name': 'support.mnemonic.privileged.m68k'
+        3: 'name': 'support.mnemonic.size.m68k'
+        4: 'name': 'storage.other.register.m68k'
+        6: 'name': 'entity.name.function.m68k'
+        7: 'name': 'entity.name.function.m68k'
+        8: 'name': 'storage.other.register.privileged.m68k'
+  }
+  {
+    'match': '\\b(?i)(reset|rte|stop(\\s+(#.+)?))(?-i)\\b'
+    'captures':
+        1: 'name': 'support.mnemonic.privileged.m68k'
+        3: 'name': 'support.mnemonic.immediate.m68k'
+  }
+  {
+    'match': '\\b(?i)(move(\\.[bwl])?(\\s+(#.+)?(.+)?,(sr|usp)))(?-i)\\b'
+    'captures':
+        1: 'name': 'support.mnemonic.privileged.m68k'
+        2: 'name': 'support.mnemonic.size.m68k'
+        4: 'name': 'support.mnemonic.immediate.m68k'
+        5: 'name': 'entity.name.function.m68k'
+        6: 'name': 'storage.other.register.privileged.m68k'
+  }
+  {
+    'match': '\\b(?i)(move(\\.[bwl])?(\\s+(sr|usp),(.+)))(?-i)\\b'
+    'captures':
+        1: 'name': 'support.mnemonic.privileged.m68k'
+        2: 'name': 'support.mnemonic.size.m68k'
+        3: 'name': 'storage.other.register.m68k'
+        4: 'name': 'storage.other.register.privileged.m68k'
+  }
+  {
+    'match': '\\b(?i)((andi|eori|ori)(\\.w)?(\\s+(.+),(sr)))(?-i)\\b'
+    'captures':
+        2: 'name': 'support.mnemonic.privileged.m68k'
+        3: 'name': 'support.mnemonic.size.m68k'
+        5: 'name': 'support.mnemonic.immediate.m68k'
+        6: 'name': 'storage.other.register.privileged.m68k'
+  }
+  {
+    'match': '\\b(?i)([as]bcd(\\.b)?|(add|sub)[iqx]?(\\.[bwl])?|adda(\\.[wl])?|(and|eor|or)(i)?(\\.[bwl])?|(rox?|[al]s)[lr](\\.[bwl])?|b(chg|clr|set|tst)(\\.[bl])?|bf(chg|clr|extu|exts|ffo|ins|set|tst)|chk(\\.[wl])?|chk2(\\.[bwl])?|clr(\\.[bwl])?|cas(\\.[bwl])?|cas2(\\.[wl])?|cmp[im2]?(\\.[bwl])?|cmpa(\\.[wl])?|divs|divu|exg(\\.l)?|ext(\\.[wl])?|extb.l|illegal|lea(\\.l)?|link|move([amp])?(\\.[bwl])?|move16|moveq(\\.l)?move(\\.[bwl])?|muls|mulu|nbcd(\\.b)?|(negx?|not)(\\.[bwl])?|nop|pea(\\.l)?|reset|rte|rtri|rtd|rts|s(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)(\\.b)?|stop|swap(\\.l)?|tas(\\.b)?|trap|trapv|trap(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)|tst|tst\\.b|tst\\.w|tst\\.l|unlk|pack|unpk)(?-i)\\b'
     'name': 'support.mnemonic.m68k'
   }
+
   {
     'match': '\\b(?i)(b(ra|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs|sr)(\\.[sw])?)(?-i)\\s+(\\.?[a-zA-Z_][a-zA-Z0-9_]*)\\b'
     'captures':

--- a/grammars/m68k.cson
+++ b/grammars/m68k.cson
@@ -45,7 +45,7 @@
     'name': 'storage.other.register.m68k'
   }
   {
-    'match': '\\b(?i)([as]bcd(\\.b)?|(add|sub)[iqx]?(\\.[bwl])?|adda(\\.[wl])?|(and|eor|or)(i)?(\\.[bwl])?|(rox?|[al]s)[lr](\\.[bwl])?|b(chg|clr|set|tst)(\\.[bl])?|bf(chg|clr|extu|exts|ffo|ins|set|tst)|chk(\\.[wl])?|chk2(\\.[bwl])?|clr(\\.[bwl])?|cmp[im2]?(\\.[bwl])?|cmpa(\\.[wl])?|divs|divu|exg(\\.l)?|ext(\\.[wl])?|extb.l|illegal|lea(\\.l)?|link|move[amp](\\.[wl])?|moveq(\\.l)?|move(\\.[bwl])?|muls|mulu|nbcd(\\.b)?|(negx?|not)(\\.[bwl])?|nop|pea(\\.l)?|reset|rte|rtri|rtd|rts|s(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)(\\.b)?|stop|swap(\\.l)?|tas(\\.b)?|trap|trapv|trap(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)|tst|tst\\.b|tst\\.w|tst\\.l|unlk)(?-i)\\b'
+    'match': '\\b(?i)([as]bcd(\\.b)?|(add|sub)[iqx]?(\\.[bwl])?|adda(\\.[wl])?|(and|eor|or)(i)?(\\.[bwl])?|(rox?|[al]s)[lr](\\.[bwl])?|b(chg|clr|set|tst)(\\.[bl])?|bf(chg|clr|extu|exts|ffo|ins|set|tst)|chk(\\.[wl])?|chk2(\\.[bwl])?|clr(\\.[bwl])?|cmp[im2]?(\\.[bwl])?|cmpa(\\.[wl])?|divs|divu|exg(\\.l)?|ext(\\.[wl])?|extb.l|illegal|lea(\\.l)?|link|move[amp](\\.[wl])?|moveq(\\.l)?|move(\\.[bwl])?|muls|mulu|nbcd(\\.b)?|(negx?|not)(\\.[bwl])?|nop|pea(\\.l)?|reset|rte|rtri|rtd|rts|s(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)(\\.b)?|stop|swap(\\.l)?|tas(\\.b)?|trap|trapv|trap(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)|tst|tst\\.b|tst\\.w|tst\\.l|unlk|pack|unpk)(?-i)\\b'
     'name': 'support.mnemonic.m68k'
   }
   {

--- a/grammars/m68k.cson
+++ b/grammars/m68k.cson
@@ -82,6 +82,19 @@
         4: 'name': 'storage.other.register.privileged.m68k'
   }
   {
+    'match': '\\b(?i)(cinv[lp]|cpush[lp])\\s+(dc|ic|bc),\\((a[0-7])(?-i)\\b'
+    'captures':
+        1: 'name': 'support.mnemonic.privileged.m68k'
+        2: 'name': 'storage.other.register.privileged.m68k'
+        3: 'name': 'storage.other.register.m68k'
+  }
+  {
+    'match': '\\b(?i)(cinva|cpusha)\\s+(dc|ic|bc)(?-i)\\b'
+    'captures':
+      1: 'name': 'support.mnemonic.privileged.m68k'
+      2: 'name': 'storage.other.register.privileged.m68k'
+  }
+  {
     'match': '\\b(?i)((andi|eori|ori)(\\.w)?(\\s+(.+),(sr)))(?-i)\\b'
     'captures':
         2: 'name': 'support.mnemonic.privileged.m68k'

--- a/grammars/m68k.cson
+++ b/grammars/m68k.cson
@@ -45,7 +45,7 @@
     'name': 'storage.other.register.m68k'
   }
   {
-    'match': '\\b(?i)([as]bcd(\\.b)?|(add|sub)[iqx]?(\\.[bwl])?|adda(\\.[wl])?|(and|eor|or)(i)?(\\.[bwl])?|(rox?|[al]s)[lr](\\.[bwl])?|b(chg|clr|set|tst)(\\.[bl])?|chk(\\.[wl])?|chk2(\\.[bwl])?|clr(\\.[bwl])?|cmp[im2]?(\\.[bwl])?|cmpa(\\.[wl])?|divs|divu|exg(\\.l)?|ext(\\.[wl])?|extb.l|illegal|lea(\\.l)?|link|move[amp](\\.[wl])?|moveq(\\.l)?|move(\\.[bwl])?|muls|mulu|nbcd(\\.b)?|(negx?|not)(\\.[bwl])?|nop|pea(\\.l)?|reset|rte|rtri|rtd|rts|s(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)(\\.b)?|stop|swap(\\.l)?|tas(\\.b)?|trap|trapv|trap(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)|tst|tst\\.b|tst\\.w|tst\\.l|unlk)(?-i)\\b'
+    'match': '\\b(?i)([as]bcd(\\.b)?|(add|sub)[iqx]?(\\.[bwl])?|adda(\\.[wl])?|(and|eor|or)(i)?(\\.[bwl])?|(rox?|[al]s)[lr](\\.[bwl])?|b(chg|clr|set|tst)(\\.[bl])?|bf(chg|clr|extu|exts|ffo|ins|set|tst)|chk(\\.[wl])?|chk2(\\.[bwl])?|clr(\\.[bwl])?|cmp[im2]?(\\.[bwl])?|cmpa(\\.[wl])?|divs|divu|exg(\\.l)?|ext(\\.[wl])?|extb.l|illegal|lea(\\.l)?|link|move[amp](\\.[wl])?|moveq(\\.l)?|move(\\.[bwl])?|muls|mulu|nbcd(\\.b)?|(negx?|not)(\\.[bwl])?|nop|pea(\\.l)?|reset|rte|rtri|rtd|rts|s(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)(\\.b)?|stop|swap(\\.l)?|tas(\\.b)?|trap|trapv|trap(f|t|cc|hs|cs|lo|eq|ge|gt|hi|le|ls|lt|mi|ne|pl|vc|vs)|tst|tst\\.b|tst\\.w|tst\\.l|unlk)(?-i)\\b'
     'name': 'support.mnemonic.m68k'
   }
   {


### PR DESCRIPTION
Hey again!

Today I have another bunch of patches for you if you want them. This time we have the 020+ instructions, special cases for privileged instructions and registers including cache control.

Next on the assembly line are the MMU and FPU opcodes.

Some more (optional) support less-classes were added, and perhaps I should provide some documentation on these some time (e.g. .support.mnemonic.privileged) :)

Have a great day,
-Kåre

PS: I did some research which resulted in a source file containing lots and lots of opcodes and addressing modes for testing. It can be found here: http://pastebin.com/39Jfn4Sf
